### PR TITLE
Remove PyCrypto and M2Crypto as top level dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,18 +7,13 @@ version = '1.0.1'
 
 # Please update tox.ini when modifying dependency version requirements
 install_requires = [
-    'pycrypto>=2.6',
     'cryptography',
     'setuptools>=1.0',
     'six',
     'future',
     'coloredlogs',
     'pgpdump',
-    'apk_parse_ph4>=0.1.7',
-    'pyx509_ph4',
     'python-dateutil',
-    'pyjks',
-    'M2Crypto'
 ]
 
 dev_extras = [
@@ -31,6 +26,11 @@ docs_extras = [
     'Sphinx>=1.0',  # autodoc_member_order = 'bysource', autodoc_default_flags
     'sphinx_rtd_theme',
     'sphinxcontrib-programoutput',
+]
+
+apk_jks_extras = [
+    'apk_parse_ph4>=0.1.7',
+    'pyjks',
 ]
 
 try:
@@ -72,6 +72,7 @@ setup(
     extras_require={
         'dev': dev_extras,
         'docs': docs_extras,
+        'apk-jks': apk_jks_extras,
     },
 
     entry_points={


### PR DESCRIPTION
This PR attempts to make it easier to install this package via `pip`. It moves to using `cryptography` (which was already a dependency) where `PyCrypto` and `M2Crypto` were previously used. Note that the `M2Crypto` replacement code leverages some non-public API of `cryptography`, but this is essentially stable private API surface (I am one of the `cryptography` developers and I've filed #3983 to start the initial PKCS7/SMIME/CMS work).

Additionally this moves `pyjks` and `apk_parse_ph4` to an optional extra to make it easier to install the package in the general case. pyjks brings along a number of additional deps (including `pycryptodome`, a fork of `PyCrypto`), and `apk_parse_ph4` also depends on `M2Crypto`.

Finally, `pyx509_ph4` does not appear to be used anywhere so the dep has been removed.