### PR TITLE
Only call process_dir on directories

### DIFF
--- a/roca/detect.py
+++ b/roca/detect.py
@@ -727,7 +727,7 @@ class RocaFingerprinter(object):
                     sub = self.process_file(fh.read(), fname)
                     ret.append(sub)
 
-            else:
+            elif os.path.isdir(full_path):
                 sub = self.process_dir(full_path)
                 ret.append(sub)
         return ret


### PR DESCRIPTION
There are mor than files and directories in a filesystem (named pipes,
    etc. …) so should only call process_dir if a directory.