### PR TITLE
Add an alternative instruction to run via Docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,3 +165,12 @@ pyenv install 2.7.13
 pyenv local 2.7.13
 ```
 
+### Docker container
+
+Run via Docker container to avoid environment inconsistency. Dockerfile source can be audited at https://hub.docker.com/r/unnawut/roca-detect/.
+
+```
+docker run --rm -v /path/to/your/keys:/keys --network none unnawut/roca-detect
+```
+
+Make sure to use `--rm` and `--network none` flags to disable container's network connection and delete the container after running.


### PR DESCRIPTION
Not sure if this is an appropriate PR or not. I created a Docker image so that the ROCA check can be done with a single command (if you have Docker installed) and consistent across most environments. This would help avoid problems like #1 and #14. 

So I have included a one-line command instruction here. I could easily open a PR to add the Dockerfile to this repo, but then we don't get the niceties of having the docker image on Docker Hub.

Happy to hear other suggestions as well.