### PR TITLE
Scanning MS crypto stores

### DIFF
--- a/csharp/.gitignore
+++ b/csharp/.gitignore
@@ -1,0 +1,5 @@
+packages
+.vs
+RocaTest/bin
+RocaTest/obj
+*.user

--- a/csharp/RocaTest/ArgumentParser.cs
+++ b/csharp/RocaTest/ArgumentParser.cs
@@ -1,0 +1,50 @@
+﻿namespace RocaTest
+{
+    using System.Collections.Generic;
+    internal class ArgumentParser
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArgumentParser"/> class.
+        /// </summary>
+        /// <param name="args">
+        /// The args.
+        /// </param>
+        internal ArgumentParser(IReadOnlyList<string> args)
+        {
+            this.DirectoryNames = new List<string>();
+            foreach (string arg in args)
+            {
+                switch (arg.ToLower())
+                {
+                    case "-my":
+                        this.ShouldParseMyStore = true;
+                        break;
+                    case "-root":
+                        this.ShouldParseRootStore = true;
+                        break;
+                    case "-allstores":
+                        this.ShouldParseAllStores = true;
+                        break;
+                    case "-v":
+                        this.Verbose = true;
+                        break;
+                    default:
+                        this.ShouldParseDirectory = true;
+                        this.DirectoryNames.Add(arg);
+                        break;
+                }
+            }
+        }
+
+        public bool Verbose { get; set; }
+
+        public bool ShouldParseDirectory { get; private set; }
+        public bool ShouldParseMyStore { get; private set; }
+        public bool ShouldParseRootStore { get; private set; }
+
+        public bool ShouldParseAllStores { get; private set; }
+
+        public List<string> DirectoryNames { get; private set; }
+
+    }
+}

--- a/csharp/RocaTest/Program.cs
+++ b/csharp/RocaTest/Program.cs
@@ -1,29 +1,171 @@
-﻿using System;
-using System.IO;
-using Org.BouncyCastle.Crypto.Parameters;
-using Org.BouncyCastle.X509;
-
-namespace RocaTest
+﻿namespace RocaTest
 {
-    class Program
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Security.Cryptography.X509Certificates;
+
+    using Org.BouncyCastle.Crypto.Parameters;
+    using Org.BouncyCastle.X509;
+
+    using X509Certificate = Org.BouncyCastle.X509.X509Certificate;
+
+    public class Program
     {
         static void Main(string[] args)
         {
-            foreach (string certFile in Directory.GetFiles("data"))
+            Console.WriteLine("ROCA detection tool https://github.com/crocs-muni/roca");
+            if (args.Length == 0)
             {
-                if (TestCert(certFile))
-                    Console.WriteLine(certFile + " - contains RSA public key vulnerable to ROCA (CVE-2017-15361)");
-                else
-                    Console.WriteLine(certFile + " - Certificate does not contain RSA public key vulnerable to ROCA (CVE-2017-15361)");
+                WriteUsage();
+                return;
+            }
+
+            var argumentParser = new ArgumentParser(args);
+
+            if (argumentParser.ShouldParseDirectory)
+            {
+                TestDirectories(argumentParser.Verbose, argumentParser.DirectoryNames);
+            }
+
+            if (!argumentParser.ShouldParseAllStores)
+            {
+                if (argumentParser.ShouldParseMyStore)
+                {
+                    TestStore(argumentParser.Verbose, StoreName.My, StoreLocation.CurrentUser);
+                }
+
+                if (argumentParser.ShouldParseRootStore)
+                {
+                    TestStore(argumentParser.Verbose, StoreName.Root, StoreLocation.CurrentUser);
+                }
+
+                return;
+            }
+
+            // Check all stores
+            foreach (StoreName storeName in Enum.GetValues(typeof(StoreName)))
+            {
+                TestStore(argumentParser.Verbose, storeName, StoreLocation.CurrentUser);
             }
         }
 
-        static bool TestCert(string certFile)
+        /// <summary>
+        /// Writes the usage to the console.
+        /// </summary>
+        private static void WriteUsage()
+        {
+            Console.WriteLine("Usage:");
+            Console.WriteLine("RocaTest <directory> Scans a directory for certificates and tests them.");
+            Console.WriteLine("RocaTest -my         Scans the personal MY store for vulnerable certificates.");
+            Console.WriteLine("RocaTest -root       Scans the personal ROOT store for vulnerable certificates.");
+            Console.WriteLine("RocaTest -allstores  Scans all store for vulnerable certificates");
+            Console.WriteLine("RocaTest -v          Adds verbose output.");
+        }
+
+        /// <summary>
+        /// Test all certificate files in directories.
+        /// </summary>
+        /// <param name="verbose">     
+        /// If output should be verbose.
+        /// </param>
+        /// <param name="directoryNames">
+        /// The directory names.
+        /// </param>
+        private static void TestDirectories(bool verbose, IEnumerable<string> directoryNames)
+        {
+            foreach (var directoryName in directoryNames)
+            {
+                Console.WriteLine();
+                Console.WriteLine("Checking directory " + directoryName);
+                if (!Directory.Exists(directoryName))
+                {
+                    Console.WriteLine("Directory doesn't exist: " + directoryName);
+                    continue;
+                }
+
+                foreach (var certFile in Directory.GetFiles(directoryName))
+                {
+                    var fileBytes = File.ReadAllBytes(certFile);
+                    if (TestCert(fileBytes))
+                    {
+                        Console.WriteLine(
+                            certFile + " - contains RSA public key vulnerable to ROCA (CVE-2017-15361)");
+                    }
+                    else
+                    {
+                        if (verbose)
+                        {
+                            Console.WriteLine(certFile + " - Certificate does not contain RSA public key vulnerable to ROCA (CVE-2017-15361)");
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Test a certificate for roca.
+        /// </summary>
+        /// <param name="fileBytes">
+        /// The file bytes.
+        /// </param>
+        /// <returns>
+        /// True if vulnerable.
+        /// </returns>
+        private static bool TestCert(byte[] fileBytes)
         {
             X509CertificateParser x509CertificateParser = new X509CertificateParser();
-            X509Certificate x509Certificate = x509CertificateParser.ReadCertificate(File.ReadAllBytes(certFile));
+            X509Certificate x509Certificate = x509CertificateParser.ReadCertificate(fileBytes);
             RsaKeyParameters rsaKeyParameters = x509Certificate.GetPublicKey() as RsaKeyParameters;
             return RocaTest.IsVulnerable(rsaKeyParameters);
+        }
+
+        /// <summary>
+        /// The test store.
+        /// </summary>
+        /// <param name="verbose">
+        /// If output should be verbose.
+        /// </param>
+        /// <param name="name">
+        /// The name.
+        /// </param>
+        /// <param name="location">
+        /// The location.
+        /// </param>
+        private static void TestStore(bool verbose, StoreName name, StoreLocation location)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Checking store \"" + name + "\".");
+
+            var vulnFound = false;
+            using (var store = new X509Store(name, location))
+            {
+                store.Open(OpenFlags.MaxAllowed);
+                foreach (var certificate in store.Certificates)
+                {
+                    var fileBytes = certificate.RawData;
+                    if (TestCert(fileBytes))
+                    {
+                        vulnFound = true;
+                        Console.WriteLine(
+                            certificate.Subject + " - contains RSA public key vulnerable to ROCA (CVE-2017-15361)");
+                    }
+                    else
+                    {
+                        if (verbose)
+                        {
+                            Console.WriteLine(
+                                certificate.Subject
+                                + " - Certificate does not contain RSA public key vulnerable to ROCA (CVE-2017-15361)");
+                        }
+                    }
+                }
+            }
+
+            if (!vulnFound)
+            {
+                Console.WriteLine("No vulnerable certificates found in \"" + name + "\" store.");
+            }
         }
     }
 }

--- a/csharp/RocaTest/RocaTest.csproj
+++ b/csharp/RocaTest/RocaTest.csproj
@@ -38,6 +38,7 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ArgumentParser.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RocaTest.cs" />


### PR DESCRIPTION
Hi!
Thank you for publishing these tools.

I saw a need to check certificates within the MS cryptoapi store without exporting them as files. It's been implemented in this pull request by adding a number of arguments to the console application.

```
ROCA detection tool https://github.com/crocs-muni/roca
Usage:
RocaTest <directory> Scans a directory for certificates and tests them.
RocaTest -my         Scans the personal MY store for vulnerable certificates.
RocaTest -root       Scans the personal ROOT store for vulnerable certificates.
RocaTest -allstores  Scans all store for vulnerable certificates
RocaTest -v          Adds verbose output.
```
