### PR TITLE
add support for TPM generated RSA public key modulus using tpm2-tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,13 @@ Currently the tool supports the following key formats:
 - Java Key Store file (JKS). Tries empty password & some common, specify more with `--jks-pass-file`
 - PKCS7 signature with user certificate
 - TPM generated binary modulus from an RSA public key *.tpmmod, generated with tpm2-tools
+
 	example:
+	
 		tpm2_createprimary -A e -g 0x000B -G 0x0001 -C primary_object.ctx
+		
 		tpm2_create -c primary_object.ctx -g 0x000B -G 0x0001 -o key.pub
+		
 		dd if=key.pub of=key.tpmmod bs=1 skip=102 count=256
 
 The detection tool is intentionally one-file implementation for easy integration / manipulation.

--- a/README.md
+++ b/README.md
@@ -37,9 +37,7 @@ Currently the tool supports the following key formats:
 	example:
 	
 		tpm2_createprimary -A e -g 0x000B -G 0x0001 -C primary_object.ctx
-		
 		tpm2_create -c primary_object.ctx -g 0x000B -G 0x0001 -o key.pub
-		
 		dd if=key.pub of=key.tpmmod bs=1 skip=102 count=256
 
 The detection tool is intentionally one-file implementation for easy integration / manipulation.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ Currently the tool supports the following key formats:
 - LDIFF file - LDAP database dump. Any field ending with `;binary::` is attempted to decode as X509 certificate
 - Java Key Store file (JKS). Tries empty password & some common, specify more with `--jks-pass-file`
 - PKCS7 signature with user certificate
+- TPM generated binary modulus from an RSA public key *.tpmmod, generated with tpm2-tools
+	example:
+		tpm2_createprimary -A e -g 0x000B -G 0x0001 -C primary_object.ctx
+		tpm2_create -c primary_object.ctx -g 0x000B -G 0x0001 -o key.pub
+		dd if=key.pub of=key.tpmmod bs=1 skip=102 count=256
 
 The detection tool is intentionally one-file implementation for easy integration / manipulation.
 

--- a/roca/detect.py
+++ b/roca/detect.py
@@ -2096,11 +2096,11 @@ class RocaFingerprinter(object):
         :param name:
         :return:
         """
-		with open(name, "rb") as bfile:
-			bdata = bfile.read()
-		hdata = binascii.hexlify(bdata)
-		modulus = int(hdata, 16)
-		self.process_binary_mod(modulus, name)
+        with open(name, "rb") as bfile:
+            bdata = bfile.read()
+        hdata = binascii.hexlify(bdata)
+        modulus = int(hdata, 16)
+        self.process_binary_mod(modulus, name)
 
     def process_binary_mod(self, modulus, name):
         """


### PR DESCRIPTION
This processes one RSA public key modulus per .tpmmod file. These files can be generated using the method specified in the README.md changes.