### PR TITLE
Fix errors in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 include README.md
 include LICENSE
-fingerprint/tests/data/*
-test.sh
+include roca/tests/data/*
+include test.sh
 
 
 


### PR DESCRIPTION
Running setup.py sdist would result in the following warnings:

{{{
warning: manifest_maker: MANIFEST.in, line 3: unknown action 'fingerprint/tests/data/*'
warning: manifest_maker: MANIFEST.in, line 4: unknown action 'test.sh'
}}}

and the resulting tarball, once extracted, would not pass unit tests.

This prevents creating debian packages using python-stdeb